### PR TITLE
コメント欄のアバターに縦長の黒い楕円枠が出る問題を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/
 composer.lock
 assets/
 wp-dependencies.json
+tmp/

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
         "php-stubs/wp-cli-stubs": "^2.11"
     },
     "config": {
+        "platform": {
+            "php": "8.2"
+        },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         }

--- a/src/scss/components/_comments.scss
+++ b/src/scss/components/_comments.scss
@@ -1,0 +1,12 @@
+// WordPress の wp-includes/css/dist/editor/style.min.css が front-end にも読み込まれる際、
+// エディタ内部の別コンポーネント向け .comment-avatar ルール（border-radius: 50% と
+// border-style: solid）がテーマの .comment-avatar と衝突する。親テーマの width: 80px と
+// flex-stretch された高さの組み合わせで、縦長の楕円の黒枠が描画される。
+// そのプロパティ群を明示的にリセットする。
+.comment-avatar {
+	background: transparent;
+	border: 0;
+	border-radius: 0;
+	margin-left: 0;
+	padding: 0;
+}

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -11,6 +11,7 @@ $notice-color: darken( $notice-hover-color, 10 );
 @import "components/bubble";
 @import "components/calendar";
 @import "components/card";
+@import "components/comments";
 @import "components/contributor";
 @import "components/form";
 @import "components/job";


### PR DESCRIPTION
## Issue

プロダクションのコメント欄でアバター画像の下にビヨーンと伸びた縦長の楕円の黒枠が描画されていた。

スクリーンショット: (ローカル tmp/ に配置、\`.gitignore\` 済み)

## 原因

親テーマ \`side-business\` の \`.comment-avatar\` は \`width: 80px\` / \`flex-shrink: 0\` で、border 系は一切持たない。しかし WordPress コアのエディタ CSS \`wp-includes/css/dist/editor/style.min.css\` にも同名クラスのルールが含まれている:

\`\`\`css
.comment-avatar {
  background: #fff;
  border-radius: 50%;
  border-style: solid;
  border-width: var(--wp-admin-border-width-focus);
  margin-left: -12px;
  padding: var(--wp-admin-border-width-focus);
  width: 24px;
}
\`\`\`

本番では Jetpack か performance 系プラグインの deferred CSS パターン（\`media="print"\` → onload で \`media="all"\`）でこの CSS が front-end にも注入されている。\`width: 80px\` は親テーマに負けるが、\`border-radius: 50%\` と \`border-style: solid\` は残り、\`.comment-item\` の flex-stretch によって縦に伸びた 80px 幅の要素が縦長楕円の枠に。

ローカル開発環境では該当プラグインが有効になっていない／条件を満たさないため editor CSS が front-end に入らず、再現しない。

## 修正

子テーマで \`.comment-avatar\` の衝突プロパティを明示リセット:

\`\`\`scss
.comment-avatar {
  background: transparent;
  border: 0;
  border-radius: 0;
  margin-left: 0;
  padding: 0;
}
\`\`\`

editor CSS がどこからロードされても、子テーマ側で打ち消される。

## Test plan

- [x] ローカルで \`npm run build:css\` / \`npm run package\` が通る
- [ ] デプロイ後、本番の https://capitalp.jp/2026/04/20/wordcamp-asia-2026-report/ で黒枠が消えていることを確認