### PR TITLE
release-drafter のタグ形式を既存 (3.0.2) に合わせる

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: 'v$RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
 categories:
   - title: 'Features'
     labels:


### PR DESCRIPTION
## Summary

release-drafter が生成するドラフトリリースのタグを \`v$RESOLVED_VERSION\` から \`$RESOLVED_VERSION\` に変更。

既存のリポジトリタグは \`3.0.2\` / \`3.0.1\` / \`2.6.0\` のように \`v\` プレフィックスなしで運用されている。drafter 設定が \`v\` 付きだと形式が割れるため揃える。

## Note

既存のドラフト（\`3.0.3\`）は master マージ時に drafter が更新するので自動で整合。v プレフィックスで作成済みのドラフトがある場合は手動で削除するか、drafter が新しいタグで上書きする。