### PR TITLE
デプロイ時に style.css の Version ヘッダを自動書き換え

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,11 @@ on:
     types:
       - published
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'バージョン文字列（例: 3.0.3）。空ならヘッダ書き換えをスキップ。'
+        required: false
+        type: string
 
 concurrency:
   group: pressable-production
@@ -19,6 +24,20 @@ jobs:
       url: https://capitalp.jp
     steps:
       - uses: actions/checkout@v4
+
+      - name: Bump theme version in style.css
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          DISPATCH_TAG: ${{ inputs.tag }}
+        run: |
+          VERSION="${RELEASE_TAG:-$DISPATCH_TAG}"
+          if [ -z "$VERSION" ]; then
+            echo "No version provided; leaving style.css untouched."
+            exit 0
+          fi
+          sed -i "s/^Version: .*/Version: ${VERSION}/" style.css
+          echo "Bumped style.css Version to ${VERSION}"
+          grep '^Version:' style.css
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Summary

GitHub Release 公開時、デプロイワークフローの冒頭で \`style.css\` のテーマヘッダ \`Version: ...\` を release タグに合わせて sed で書き換えてから rsync する。

## 動作

- **\`release.published\` 起動**: \`github.event.release.tag_name\`（例: \`3.0.3\`）を採用
- **\`workflow_dispatch\` 起動**: 新規の \`inputs.tag\` から採用。空なら書き換えスキップ

書き換えはデプロイジョブの作業ツリー内だけで、リポジトリには書き戻さない（スコープを小さく保つため）。リポジトリ上の \`style.css\` は開発者が手動で bump するか、別途自動化するか選べる。

## Test plan

- [ ] \`workflow_dispatch\` で \`tag: 3.0.3\` を指定して空打ちし、ログに \`Bumped style.css Version to 3.0.3\` が出ることを確認
- [ ] Pressable 側の \`style.css\` ヘッダが \`3.0.3\` になっていることを確認
- [ ] \`workflow_dispatch\` で tag を空欄にし、書き換えスキップログが出ることを確認