### PR TITLE
rsync のプロトコルを 31 に固定（Pressable との不整合回避）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,9 @@ jobs:
       - name: Deploy theme via rsync
         env:
           SSH_USER: ${{ secrets.PRESSABLE_SSH_USER }}
+        # --protocol=31 は runner 側 rsync 3.2.7 と Pressable 側 rsync の
+        # プロトコル不整合（"unexpected tag 103" エラー）を回避するため。
         run: |
-          rsync -avz --delete \
+          rsync -avz --delete --protocol=31 \
             --exclude-from=.distignore \
             ./ "${SSH_USER}@ssh.pressable.com:/home/${SSH_USER}/htdocs/wp-content/themes/capitalp/"


### PR DESCRIPTION
## 状況

PR #24 がマージ後、release publish でデプロイが走ったが rsync 転送中に失敗:

\`\`\`
sending incremental file list
unexpected tag 103 [sender/inc]
rsync error: error in rsync protocol data stream (code 12) at io.c(1705) [sender=3.2.7]
\`\`\`

## 原因

GitHub Actions runner の rsync (3.2.7) と Pressable 側 rsync の間でプロトコル不整合。SSH 接続・認証・ファイルリスト送信までは成功していて、実データ転送のフェーズでプロトコルの特定メッセージ (tag 103) を older receiver が認識できずに落ちる既知の問題。

## 修正

\`rsync --protocol=31\` で older protocol に固定。これは rsync の標準機能で、managed hosting 向けでは定番のワークアラウンド。

## 鍵の露出について (FAQ)

失敗時のログに長い \`ssh-rsa AAAA...\` が出てびっくりしたかもしれないけど、これは **公開鍵**（webfactory/ssh-agent が情報として出力）で、秘密鍵ではない。秘密鍵は \`ssh-private-key: ***\` のように redact されている。\`SSH_USER: ***\` も redact 済み。セキュリティ上の問題はなし。

## Test plan

- [ ] この PR マージ後、release publish または \`workflow_dispatch\` で実走してエラーが解消されることを確認
- [ ] 失敗する場合のフォールバック: \`--protocol=30\`、それでも駄目なら runner に rsync 3.1.3 をビルド/インストール