### PR TITLE
デプロイを Pressable 公式手順（scp + 遠隔 rsync）に切り替え

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,5 +1,6 @@
-# Files and directories excluded from production deploy (rsync --exclude-from).
-# Syntax is rsync's; patterns are matched against paths relative to the theme root.
+# Files and directories excluded from the production deploy archive.
+# Used by `tar --exclude-from` in .github/workflows/deploy.yml. Syntax is
+# glob-style; the file is also compatible with rsync's --exclude-from.
 
 # VCS / CI
 .git/
@@ -10,6 +11,8 @@
 # Local dev environment
 .docker/
 .DS_Store
+.husky/
+tmp/
 
 # Source files (built output lives in assets/)
 src/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,12 +70,34 @@ jobs:
       - name: Add Pressable host to known_hosts
         run: ssh-keyscan -H ssh.pressable.com >> ~/.ssh/known_hosts
 
-      - name: Deploy theme via rsync
+      # Pressable は「ローカルから rsync push」を protocol-level で拒否する
+      # （runner 側 rsync 3.2.7 で "unexpected tag 103" エラー）。公式ドキュメント
+      # https://pressable.com/knowledgebase/how-to-migrate-your-wordpress-site-to-pressable/
+      # でも scp でアーカイブを /tmp に置いてから server 側でローカル rsync を
+      # 走らせる手順が示されている。同じパターンに合わせる。
+      - name: Package theme (tar.gz)
+        run: |
+          tar czf /tmp/capitalp-deploy.tar.gz --exclude-from=.distignore -C . .
+          ls -lh /tmp/capitalp-deploy.tar.gz
+
+      - name: Upload tarball via SCP
         env:
           SSH_USER: ${{ secrets.PRESSABLE_SSH_USER }}
-        # --protocol=31 は runner 側 rsync 3.2.7 と Pressable 側 rsync の
-        # プロトコル不整合（"unexpected tag 103" エラー）を回避するため。
         run: |
-          rsync -avz --delete --protocol=31 \
-            --exclude-from=.distignore \
-            ./ "${SSH_USER}@ssh.pressable.com:/home/${SSH_USER}/htdocs/wp-content/themes/capitalp/"
+          scp -q /tmp/capitalp-deploy.tar.gz "${SSH_USER}@ssh.pressable.com:/tmp/capitalp-deploy.tar.gz"
+
+      - name: Extract and sync on Pressable
+        env:
+          SSH_USER: ${{ secrets.PRESSABLE_SSH_USER }}
+        run: |
+          ssh "${SSH_USER}@ssh.pressable.com" '
+            set -e
+            STAGE=/tmp/capitalp-deploy-stage
+            ARCHIVE=/tmp/capitalp-deploy.tar.gz
+            rm -rf "$STAGE"
+            mkdir -p "$STAGE"
+            tar xzf "$ARCHIVE" -C "$STAGE"
+            rsync -avh --delete "$STAGE/" ~/htdocs/wp-content/themes/capitalp/
+            rm -rf "$ARCHIVE" "$STAGE"
+            echo "Deploy complete."
+          '

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,8 @@ jobs:
   deploy:
     name: Deploy theme to Pressable production
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     environment:
       name: production
       url: https://capitalp.jp
@@ -75,10 +77,36 @@ jobs:
       # https://pressable.com/knowledgebase/how-to-migrate-your-wordpress-site-to-pressable/
       # でも scp でアーカイブを /tmp に置いてから server 側でローカル rsync を
       # 走らせる手順が示されている。同じパターンに合わせる。
-      - name: Package theme (tar.gz)
+      - name: Package theme (tar.gz for deploy)
         run: |
           tar czf /tmp/capitalp-deploy.tar.gz --exclude-from=.distignore -C . .
           ls -lh /tmp/capitalp-deploy.tar.gz
+
+      # WordPress の zip インストーラ規約に合わせ、capitalp/ を root に持つ zip を作る。
+      - name: Package theme (zip for release asset)
+        run: |
+          STAGE=/tmp/capitalp-zip-stage
+          rm -rf "$STAGE"
+          mkdir -p "$STAGE"
+          rsync -a --exclude-from=.distignore ./ "$STAGE/capitalp/"
+          (cd "$STAGE" && zip -qr /tmp/capitalp.zip capitalp)
+          ls -lh /tmp/capitalp.zip
+
+      - name: Upload zip as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: capitalp-theme
+          path: /tmp/capitalp.zip
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Attach zip to GitHub Release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh release upload "$TAG" /tmp/capitalp.zip --clobber --repo "$GITHUB_REPOSITORY"
 
       - name: Upload tarball via SCP
         env:


### PR DESCRIPTION
## 問題

直近のデプロイが全て rsync protocol エラーで失敗:

\`\`\`
sending incremental file list
unexpected tag 103 [sender/inc]
rsync error: error in rsync protocol data stream (code 12) at io.c(1705) [sender=3.2.7]
\`\`\`

- \`--protocol=31\` を追加しても改善せず
- SFTP ツールでは同じ鍵・ユーザーでアクセスできるので**認証・経路は正常**

## 原因

Pressable の managed 環境は **rsync over SSH exec をサポートしていない**。runner 側 rsync (3.2.7) の protocol データが server 側で壊れる／別コマンドに飲まれて、非 rsync 形式のバイト列が返るため sender が tag 103 という未知のメッセージタグを受け取って死ぬ。

Pressable 公式の [移行手順ドキュメント](https://pressable.com/knowledgebase/how-to-migrate-your-wordpress-site-to-pressable/) でも、**ローカル → server への rsync push ではなく、scp でアーカイブを \`/tmp\` に置いてサーバー側で rsync をローカル実行するパターン**が提示されている。

## 修正

deploy workflow の rsync push ステップを、Pressable 公式パターンに合わせて 3 ステップに分解:

1. **ローカル**: \`tar czf /tmp/capitalp-deploy.tar.gz --exclude-from=.distignore -C . .\`
2. **scp**: runner → server \`/tmp/capitalp-deploy.tar.gz\`
3. **ssh**: server に入り、\`tar xzf\` で展開して \`rsync -avh --delete\` をサーバー**内**で実行。終わったらステージング dir と archive を削除

ssh-agent ベースの鍵認証はそのまま利用。\`known_hosts\` 登録ステップも流用。

### .distignore の微調整

- \`.husky/\`（husky の git hook 置き場、サーバーには不要）を除外
- \`tmp/\`（ローカルで使うスクラッチ用ディレクトリ）を除外
- コメントを rsync 専用表記から tar/rsync 両対応表記に書き換え

## ローカル検証

\`\`\`
$ tar czf /tmp/capitalp-test.tar.gz --exclude-from=.distignore -C . .
$ ls -lh /tmp/capitalp-test.tar.gz
-rw-r--r--  1 guy  wheel   8.1M ...
\`\`\`

含まれるトップレベル: \`amp assets commands functions functions.php hooks languages screenshot.png style.css template-parts templates tscf.json vendor\` + \`LICENSE README.md\`。\`src/\` \`node_modules/\` \`vendor/\` の dev 部分（CI では \`composer install --no-dev\`）\`.husky/\` \`tmp/\` 等は除外されていることを確認。

## Test plan

- [ ] マージ後 \`workflow_dispatch\` で tag 無し起動（style.css は現行 3.0.2 のまま）でデプロイ成功を確認
- [ ] 成功確認後、3.0.3 release を再公開して自動デプロイが通ること
- [ ] 本番の style.css ヘッダと theme ファイル郡が期待通り更新されること