### PR TITLE
deploy の tar が .distignore を無視して node_modules 等が本番に配られる問題を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,19 +77,28 @@ jobs:
       # https://pressable.com/knowledgebase/how-to-migrate-your-wordpress-site-to-pressable/
       # でも scp でアーカイブを /tmp に置いてから server 側でローカル rsync を
       # 走らせる手順が示されている。同じパターンに合わせる。
+      #
+      # exclude ロジックは rsync のステージングに集約する。GNU tar の
+      # --exclude-from は `./` プレフィックス付きパスで trailing slash の
+      # ディレクトリパターンが期待通りにマッチしないため直接使わない。
+      - name: Stage deploy tree
+        run: |
+          STAGE=/tmp/capitalp-build
+          rm -rf "$STAGE"
+          mkdir -p "$STAGE/capitalp"
+          rsync -a --exclude-from=.distignore ./ "$STAGE/capitalp/"
+          echo "--- top level of staged tree ---"
+          find "$STAGE/capitalp" -maxdepth 1 -mindepth 1 -printf '%f\n' | sort | head -30
+
       - name: Package theme (tar.gz for deploy)
         run: |
-          tar czf /tmp/capitalp-deploy.tar.gz --exclude-from=.distignore -C . .
+          tar czf /tmp/capitalp-deploy.tar.gz -C /tmp/capitalp-build/capitalp .
           ls -lh /tmp/capitalp-deploy.tar.gz
 
-      # WordPress の zip インストーラ規約に合わせ、capitalp/ を root に持つ zip を作る。
+      # WordPress の zip インストーラ規約に合わせ、capitalp/ を root に持つ zip。
       - name: Package theme (zip for release asset)
         run: |
-          STAGE=/tmp/capitalp-zip-stage
-          rm -rf "$STAGE"
-          mkdir -p "$STAGE"
-          rsync -a --exclude-from=.distignore ./ "$STAGE/capitalp/"
-          (cd "$STAGE" && zip -qr /tmp/capitalp.zip capitalp)
+          (cd /tmp/capitalp-build && zip -qr /tmp/capitalp.zip capitalp)
           ls -lh /tmp/capitalp.zip
 
       - name: Upload zip as workflow artifact


### PR DESCRIPTION
## 問題

直近の release デプロイ後、本番サーバーのテーマディレクトリに **.git/, .github/, .husky/, src/, node_modules/(!)** が配られていた。tar アーカイブのサイズも 89MB と過大。

## 原因

\`.github/workflows/deploy.yml\` の tar が：

\`\`\`bash
tar czf /tmp/capitalp-deploy.tar.gz --exclude-from=.distignore -C . .
\`\`\`

\`-C . .\` でアーカイブ内のパスが \`./foo/bar\` 形式になる。GNU tar の \`--exclude-from\` は \`node_modules/\` のような trailing slash 付きパターンを anchored 扱いするが **\`./\` プレフィックスを考慮しない**ため、\`./node_modules/...\` にマッチしない。

ローカル開発環境 (macOS / bsdtar) はパターンマッチングの挙動が異なり、当時ローカル dry-run では正しく除外されていたので気付けなかった。Actions ログで tar が **89MB**、zip ステップの rsync が **3.1MB** という差が決定的な証拠。

## 修正

exclude ロジックを rsync のステージングに一本化し、tar / zip はステージ済みのクリーンなツリーから直接パッケージする：

\`\`\`
rsync -a --exclude-from=.distignore ./ /tmp/capitalp-build/capitalp/
tar czf /tmp/capitalp-deploy.tar.gz -C /tmp/capitalp-build/capitalp .
(cd /tmp/capitalp-build && zip -qr /tmp/capitalp.zip capitalp)
\`\`\`

rsync が GNU/BSD で一貫して動作するため、こちらに統一するのが堅い。

## ローカル検証

\`\`\`
-rw-r--r--  1 guy  wheel   8.1M  /tmp/capitalp-deploy.tar.gz
-rw-r--r--  1 guy  wheel   8.8M  /tmp/capitalp.zip
\`\`\`

含まれるトップレベル: \`amp assets commands functions functions.php hooks languages screenshot.png style.css template-parts templates tscf.json vendor\` + \`LICENSE README.md\`。\`.git .github .husky src tests node_modules composer.json package.json tmp\` 等が除外。

## 本番サーバーのクリーンアップ (別作業)

今回のミスで本番に載ってしまった \`.git .github .husky src node_modules .distignore .eslintrc .node-version .stylelintrc.json composer.json composer.lock package.json package-lock.json gulpfile.js phpcs.ruleset.xml phpstan.neon phpstan-baseline.neon wp-dependencies.json\` を SSH / SFTP で手動削除が必要。\`rsync --delete\` は次回の正常なデプロイで配られるが、\`.distignore\` 等の ignore 対象は \`--exclude\` されるため自動削除されない。

## Test plan

- [ ] マージ後 \`workflow_dispatch\` で tag 無し起動してデプロイ成功を確認
- [ ] サーバーに \`.git .husky node_modules src\` 等が**載らない**ことを確認
- [ ] artifact と（release 起動の場合は）release アセットに \`capitalp.zip\` が添付されることを確認