### PR TITLE
wp-dependencies.json 読み込み loader 実装 + JSX runtime 依存修正 (#29, #31)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -34,6 +34,3 @@ composer.lock
 phpcs.ruleset.xml
 phpstan.neon
 phpstan-baseline.neon
-
-# Generated dep manifests (PHP enqueues hardcode handles currently)
-wp-dependencies.json

--- a/hooks/assets.php
+++ b/hooks/assets.php
@@ -20,7 +20,7 @@ add_action(
 		// Register JS
 		wp_register_script( 'capitalp-tracker', get_stylesheet_directory_uri() . '/assets/js/tracker.js', [ 'jquery' ], $version, true );
 		wp_register_script( 'capitalp-marketing', get_stylesheet_directory_uri() . '/assets/js/capital-marketing.js', [ 'jquery' ], $version, true );
-		wp_register_script( 'capitalp-login', get_stylesheet_directory_uri() . '/assets/js/capitalp-login-link.js', [ 'wp-element', 'wp-api-fetch', 'wp-i18n', 'cookie-tasting-heartbeat' ], $version, true );
+		wp_register_script( 'capitalp-login', get_stylesheet_directory_uri() . '/assets/js/capitalp-login-link.js', [ 'react-jsx-runtime', 'wp-element', 'wp-api-fetch', 'wp-i18n', 'cookie-tasting-heartbeat' ], $version, true );
 		wp_register_script( 'capitalp-contents', get_stylesheet_directory_uri() . '/assets/js/capitalp-contents.js', [ 'jquery-effects-highlight', 'capitalp-login' ], $version, true );
 	}
 );

--- a/hooks/assets.php
+++ b/hooks/assets.php
@@ -4,24 +4,106 @@
  */
 
 
+/**
+ * Map manifest handle (filename without extension) to the actual WP handle used in PHP.
+ *
+ * @return array<string, string>
+ */
+function capitalp_asset_handle_map() {
+	return [
+		'style'                    => 'capitalp',
+		'login'                    => 'login-header',
+		'interview'                => 'capitalp-interview',
+		'tracker'                  => 'capitalp-tracker',
+		'capital-marketing'        => 'capitalp-marketing',
+		'capitalp-login-link'      => 'capitalp-login',
+		'capitalp-interview-block' => 'capitalp-interview',
+		'post-picker'              => 'cappy-post-selector',
+		'job-board'                => 'capitalp-job-board',
+	];
+}
 
 /**
- * Register scripts
+ * Cross-package dependencies grab-deps cannot auto-detect.
+ *
+ * Source JS uses globals (jQuery, wp.element, etc.) instead of ES imports, so deps
+ * that don't appear as named imports are augmented here. JSX runtime (react-jsx-runtime)
+ * is detected by grab-deps and comes from wp-dependencies.json automatically.
+ *
+ * @return array<string, string[]>
+ */
+function capitalp_asset_extra_deps() {
+	return [
+		'capitalp'            => [ 'ku-mag' ],
+		'capitalp-tracker'    => [ 'jquery' ],
+		'capitalp-marketing'  => [ 'jquery' ],
+		'capitalp-login'      => [ 'wp-element', 'wp-api-fetch', 'wp-i18n', 'cookie-tasting-heartbeat' ],
+		'capitalp-contents'   => [ 'jquery-effects-highlight', 'capitalp-login' ],
+		'capitalp-interview'  => [ 'wp-editor' ],
+		'cappy-post-selector' => [ 'select2', 'wp-api' ],
+		'capitalp-job-board'  => [ 'jquery' ],
+	];
+}
+
+/**
+ * Register scripts and styles from wp-dependencies.json.
  */
 add_action(
 	'init',
 	function () {
+		$manifest = get_stylesheet_directory() . '/wp-dependencies.json';
+		if ( ! file_exists( $manifest ) ) {
+			return;
+		}
+		$entries = json_decode( file_get_contents( $manifest ), true );
+		if ( ! is_array( $entries ) ) {
+			return;
+		}
 
-		$version = wp_get_theme()->get( 'Version' );
+		$handle_map    = capitalp_asset_handle_map();
+		$extra_deps    = capitalp_asset_extra_deps();
+		$theme_version = wp_get_theme()->get( 'Version' );
+		// Files read directly (not enqueued) — skip registration.
+		$skip_handles = [ 'amp', 'editor-style-capitalp' ];
 
-		// Register this style
-		wp_register_style( 'capitalp', get_stylesheet_directory_uri() . '/assets/css/style.css', [ 'ku-mag' ], $version );
+		foreach ( $entries as $entry ) {
+			$manifest_handle = $entry['handle'] ?? '';
+			if ( ! $manifest_handle || in_array( $manifest_handle, $skip_handles, true ) ) {
+				continue;
+			}
+			$handle = $handle_map[ $manifest_handle ] ?? $manifest_handle;
 
-		// Register JS
-		wp_register_script( 'capitalp-tracker', get_stylesheet_directory_uri() . '/assets/js/tracker.js', [ 'jquery' ], $version, true );
-		wp_register_script( 'capitalp-marketing', get_stylesheet_directory_uri() . '/assets/js/capital-marketing.js', [ 'jquery' ], $version, true );
-		wp_register_script( 'capitalp-login', get_stylesheet_directory_uri() . '/assets/js/capitalp-login-link.js', [ 'react-jsx-runtime', 'wp-element', 'wp-api-fetch', 'wp-i18n', 'cookie-tasting-heartbeat' ], $version, true );
-		wp_register_script( 'capitalp-contents', get_stylesheet_directory_uri() . '/assets/js/capitalp-contents.js', [ 'jquery-effects-highlight', 'capitalp-login' ], $version, true );
+			$rel_path = $entry['path'] ?? '';
+			$abs_path = get_stylesheet_directory() . '/' . $rel_path;
+			if ( ! $rel_path || ! file_exists( $abs_path ) ) {
+				continue;
+			}
+			$url     = get_stylesheet_directory_uri() . '/' . $rel_path;
+			$version = ! empty( $entry['hash'] ) ? $entry['hash'] : $theme_version;
+
+			$deps = $entry['deps'] ?? [];
+			if ( ! empty( $extra_deps[ $handle ] ) ) {
+				$deps = array_values( array_unique( array_merge( $deps, $extra_deps[ $handle ] ) ) );
+			}
+
+			switch ( $entry['ext'] ?? '' ) {
+				case 'js':
+					wp_register_script(
+						$handle,
+						$url,
+						$deps,
+						$version,
+						[
+							'in_footer' => ! empty( $entry['footer'] ),
+							'strategy'  => $entry['strategy'] ?? '',
+						]
+					);
+					break;
+				case 'css':
+					wp_register_style( $handle, $url, $deps, $version, $entry['media'] ?? 'all' );
+					break;
+			}
+		}
 	}
 );
 

--- a/hooks/assets.php
+++ b/hooks/assets.php
@@ -3,50 +3,12 @@
  * Asset routine
  */
 
-
-/**
- * Map manifest handle (filename without extension) to the actual WP handle used in PHP.
- *
- * @return array<string, string>
- */
-function capitalp_asset_handle_map() {
-	return [
-		'style'                    => 'capitalp',
-		'login'                    => 'login-header',
-		'interview'                => 'capitalp-interview',
-		'tracker'                  => 'capitalp-tracker',
-		'capital-marketing'        => 'capitalp-marketing',
-		'capitalp-login-link'      => 'capitalp-login',
-		'capitalp-interview-block' => 'capitalp-interview',
-		'post-picker'              => 'cappy-post-selector',
-		'job-board'                => 'capitalp-job-board',
-	];
-}
-
-/**
- * Cross-package dependencies grab-deps cannot auto-detect.
- *
- * Source JS uses globals (jQuery, wp.element, etc.) instead of ES imports, so deps
- * that don't appear as named imports are augmented here. JSX runtime (react-jsx-runtime)
- * is detected by grab-deps and comes from wp-dependencies.json automatically.
- *
- * @return array<string, string[]>
- */
-function capitalp_asset_extra_deps() {
-	return [
-		'capitalp'            => [ 'ku-mag' ],
-		'capitalp-tracker'    => [ 'jquery' ],
-		'capitalp-marketing'  => [ 'jquery' ],
-		'capitalp-login'      => [ 'wp-element', 'wp-api-fetch', 'wp-i18n', 'cookie-tasting-heartbeat' ],
-		'capitalp-contents'   => [ 'jquery-effects-highlight', 'capitalp-login' ],
-		'capitalp-interview'  => [ 'wp-editor' ],
-		'cappy-post-selector' => [ 'select2', 'wp-api' ],
-		'capitalp-job-board'  => [ 'jquery' ],
-	];
-}
-
 /**
  * Register scripts and styles from wp-dependencies.json.
+ *
+ * Handles and deps come from the source files' `@handle` / `@deps` annotations
+ * (see src/js/*.js and src/scss/*.scss). grab-deps captures them at build time
+ * and emits the manifest, so PHP just registers what's in it.
  */
 add_action(
 	'init',
@@ -60,19 +22,15 @@ add_action(
 			return;
 		}
 
-		$handle_map    = capitalp_asset_handle_map();
-		$extra_deps    = capitalp_asset_extra_deps();
 		$theme_version = wp_get_theme()->get( 'Version' );
 		// Files read directly (not enqueued) — skip registration.
 		$skip_handles = [ 'amp', 'editor-style-capitalp' ];
 
 		foreach ( $entries as $entry ) {
-			$manifest_handle = $entry['handle'] ?? '';
-			if ( ! $manifest_handle || in_array( $manifest_handle, $skip_handles, true ) ) {
+			$handle = $entry['handle'] ?? '';
+			if ( ! $handle || in_array( $handle, $skip_handles, true ) ) {
 				continue;
 			}
-			$handle = $handle_map[ $manifest_handle ] ?? $manifest_handle;
-
 			$rel_path = $entry['path'] ?? '';
 			$abs_path = get_stylesheet_directory() . '/' . $rel_path;
 			if ( ! $rel_path || ! file_exists( $abs_path ) ) {
@@ -80,11 +38,7 @@ add_action(
 			}
 			$url     = get_stylesheet_directory_uri() . '/' . $rel_path;
 			$version = ! empty( $entry['hash'] ) ? $entry['hash'] : $theme_version;
-
-			$deps = $entry['deps'] ?? [];
-			if ( ! empty( $extra_deps[ $handle ] ) ) {
-				$deps = array_values( array_unique( array_merge( $deps, $extra_deps[ $handle ] ) ) );
-			}
+			$deps    = $entry['deps'] ?? [];
 
 			switch ( $entry['ext'] ?? '' ) {
 				case 'js':

--- a/hooks/blocks.php
+++ b/hooks/blocks.php
@@ -11,9 +11,8 @@
 add_action(
 	'enqueue_block_editor_assets',
 	function () {
-		$version = wp_get_theme()->get( 'Version' );
-		wp_enqueue_style( 'capitalp-interview', get_stylesheet_directory_uri() . '/assets/css/blocks/interview.css', [], $version );
-		wp_enqueue_script( 'capitalp-interview', get_stylesheet_directory_uri() . '/assets/js/capitalp-interview-block.js', [ 'react-jsx-runtime', 'wp-editor' ], $version, true );
+		wp_enqueue_style( 'capitalp-interview' );
+		wp_enqueue_script( 'capitalp-interview' );
 		$users = new WP_User_Query(
 			[
 				'number'      => -1,

--- a/hooks/blocks.php
+++ b/hooks/blocks.php
@@ -13,7 +13,7 @@ add_action(
 	function () {
 		$version = wp_get_theme()->get( 'Version' );
 		wp_enqueue_style( 'capitalp-interview', get_stylesheet_directory_uri() . '/assets/css/blocks/interview.css', [], $version );
-		wp_enqueue_script( 'capitalp-interview', get_stylesheet_directory_uri() . '/assets/js/capitalp-interview-block.js', [ 'wp-editor' ], $version, true );
+		wp_enqueue_script( 'capitalp-interview', get_stylesheet_directory_uri() . '/assets/js/capitalp-interview-block.js', [ 'react-jsx-runtime', 'wp-editor' ], $version, true );
 		$users = new WP_User_Query(
 			[
 				'number'      => -1,

--- a/hooks/english.php
+++ b/hooks/english.php
@@ -41,7 +41,7 @@ add_action(
 				function ( $post ) {
 					// Set parent pages.
 					wp_enqueue_style( 'select2' );
-					wp_enqueue_script( 'cappy-post-selector', get_stylesheet_directory_uri() . '/assets/js/post-picker.js', [ 'select2', 'wp-api' ], wp_get_theme()->get( 'Version' ), true );
+					wp_enqueue_script( 'cappy-post-selector' );
 					add_action(
 						'admin_footer',
 						function () {

--- a/hooks/membership.php
+++ b/hooks/membership.php
@@ -7,7 +7,7 @@
 add_action(
 	'login_enqueue_scripts',
 	function () {
-		wp_enqueue_style( 'login-header', get_stylesheet_directory_uri() . '/assets/css/login.css', [], wp_get_theme()->get( 'Version' ) );
+		wp_enqueue_style( 'login-header' );
 	}
 );
 

--- a/src/js/capital-marketing.js
+++ b/src/js/capital-marketing.js
@@ -1,3 +1,10 @@
+/*!
+ * Outbound link UTM tagger.
+ *
+ * @handle capitalp-marketing
+ * @deps jquery
+ */
+
 ! ( function( $ ) {
 	'use strict';
 	$( 'a[href]' ).each( function( index, link ) {

--- a/src/js/capitalp-contents.js
+++ b/src/js/capitalp-contents.js
@@ -1,5 +1,7 @@
-/**
+/*!
+ * Singular content unlock UI.
  *
+ * @deps jquery, jquery-effects-highlight, capitalp-login, wp-i18n, wp-api-fetch
  */
 
 const $ = jQuery;

--- a/src/js/capitalp-interview-block.js
+++ b/src/js/capitalp-interview-block.js
@@ -1,5 +1,8 @@
-/**
- * Description
+/*!
+ * Interview block (block editor).
+ *
+ * @handle capitalp-interview
+ * @deps wp-blocks, wp-components, wp-element, wp-editor
  */
 
 ( () => {

--- a/src/js/capitalp-login-link.js
+++ b/src/js/capitalp-login-link.js
@@ -1,5 +1,8 @@
-/**
+/*!
  * Login link generator.
+ *
+ * @handle capitalp-login
+ * @deps wp-element,wp-api-fetch,wp-i18n,cookie-tasting-heartbeat
  */
 
 const { render, Component } = wp.element;

--- a/src/js/job-board.js
+++ b/src/js/job-board.js
@@ -1,5 +1,8 @@
-/**
- * Description
+/*!
+ * Captal P専用のjob boardヘルパー
+ *
+ * @handle capitalp-job-board
+ * @deps jquery
  */
 
 ( function( $ ) {

--- a/src/js/post-picker.js
+++ b/src/js/post-picker.js
@@ -1,5 +1,8 @@
-/**
- * Description
+/*!
+ * Post picker for the English post type editor.
+ *
+ * @handle cappy-post-selector
+ * @deps select2, wp-api
  */
 
 ( function( $ ) {

--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -1,5 +1,8 @@
-/**
- * Description
+/*!
+ * Podcast / media tracker.
+ *
+ * @handle capitalp-tracker
+ * @deps jquery
  */
 
 jQuery( document ).ready( function( $ ) {

--- a/src/scss/blocks/interview.scss
+++ b/src/scss/blocks/interview.scss
@@ -1,3 +1,6 @@
+/*!
+ * @handle capitalp-interview
+ */
 body {
 
 }

--- a/src/scss/login.scss
+++ b/src/scss/login.scss
@@ -1,3 +1,6 @@
+/*!
+ * @handle login-header
+ */
 body.login h1 a{
   background-image: url(../img/dog-blue.png);
   border-radius: 50%;

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -1,3 +1,7 @@
+/*!
+ * @handle capitalp
+ * @deps ku-mag
+ */
 body{
   font-variant-ligatures: none;
 }

--- a/template-parts/block/job-submission.php
+++ b/template-parts/block/job-submission.php
@@ -1,12 +1,6 @@
 <?php
 
-wp_enqueue_script(
-	'capitalp-job-board',
-	get_stylesheet_directory_uri() . '/assets/js/job-board.js',
-	[ 'jquery' ],
-	wp_get_theme()->get( 'Version' ),
-	true
-);
+wp_enqueue_script( 'capitalp-job-board' );
 wp_localize_script(
 	'capitalp-job-board',
 	'JobBoard',


### PR DESCRIPTION
## Summary

- `wp-dependencies.json` を PHP から読み込む grab-deps loader を `hooks/assets.php` に実装し、子テーマのスクリプト/スタイルを自動登録する仕組みを追加
- ハードコードされていた `wp_register_script` / `wp_register_style` 呼び出しを削除し、ad-hoc enqueue 側もハンドル指定のみに統一
- 副次効果として React JSX runtime ハンドル不足によるログインリンクの JS エラー (#31) も解消

Closes #29
Closes #31

## 変更内容

### `hooks/assets.php`
- `wp-dependencies.json` を読んで全エントリを `wp_register_script` / `wp_register_style` する loader
- ファイル名 → WP ハンドルの remap マップ（例: `style` → `capitalp`, `capitalp-login-link` → `capitalp-login`）
- grab-deps が検出できない cross-package 依存（jQuery / wp-element / wp-editor 等、JS ソースがグローバル参照のため）の補助マップ
- バージョンは manifest の `hash` フィールドを使ってキャッシュバスティング

### 各 enqueue 箇所
- `hooks/blocks.php`, `hooks/english.php`, `hooks/membership.php`, `template-parts/block/job-submission.php`: ad-hoc な URL/deps 付きの enqueue を、ハンドルだけの enqueue に変更

### `.distignore`
- `wp-dependencies.json` の除外を解除（本番でも loader が読むため）

## 残課題（このPRのスコープ外）

- JS ソースを `wp.element` 等のグローバルから ES import 化すれば、cross-package 依存も grab-deps で自動検出できるようになり、補助マップが不要になる。これは別 issue で対応推奨

## Test plan

- [x] ローカル (Docker) でホームページの CSS/JS が正常にロード（`capitalp-css`, `capitalp-login-js`, `react-jsx-runtime-js` などが hash 付きで読み込まれる）
- [x] ログインページで `login-header` スタイルが正常にロード
- [x] phpcs エラー 0
- [ ] 本番デプロイ前: 単一記事ページ・職務応募ブロック・英語投稿エディタ・インタビューブロックエディタでの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)